### PR TITLE
feat: Add GCP deployment docs and server health check

### DIFF
--- a/ARTIFACT_REGISTRY_SETUP.md
+++ b/ARTIFACT_REGISTRY_SETUP.md
@@ -1,0 +1,50 @@
+# Artifact Registry Setup for Docker Images
+
+This guide explains how to create a Docker repository in Google Cloud Artifact Registry. This repository will be used to store your Docker images, which can then be deployed to services like Cloud Run.
+
+## 1. Navigate to Artifact Registry
+
+*   **Using the Search Bar (Recommended):**
+    *   In the Google Cloud Console, locate the search bar at the top of the page.
+    *   Type "**Artifact Registry**" and press Enter.
+    *   Select "Artifact Registry" from the search results.
+*   **Using the Navigation Menu:**
+    *   Click the **Navigation Menu** (the three horizontal lines in the top-left corner).
+    *   Scroll down or filter to find "**Artifact Registry**" (it might be under "CI/CD" or a similar category).
+    *   Click on it.
+
+## 2. Create a Repository
+
+*   Once in the Artifact Registry section, click the "**CREATE REPOSITORY**" button. If you have existing repositories, this button might be located above the list of repositories.
+*   **Configure the new repository:**
+    *   **Name:** Enter a unique name for your repository.
+        *   *Example:* `gpt-researcher-repo`
+    *   **Format:** Select "**Docker**" from the dropdown menu. This specifies that the repository will store Docker container images.
+    *   **Mode:** Keep the default "Standard" mode unless you have specific requirements for a "Remote" or "Virtual" repository.
+    *   **Location Type:** Choose "**Region**".
+    *   **Region:** Select a region for your repository.
+        *   *Recommendation:* Choose the same region where you plan to run your Cloud Run services or other resources that will access this repository (e.g., `us-central1`, `europe-west1`). This can reduce latency and costs.
+    *   **Description:** (Optional) Add a description for your repository.
+    *   **Labels:** (Optional) Add any labels if you use them for organizing resources.
+    *   **Encryption:** Leave the "Google-managed encryption key" selected unless you have specific requirements to use a "Customer-managed encryption key (CMEK)".
+*   Click the "**CREATE**" button at the bottom of the page.
+
+## 3. Note the Repository Path
+
+*   After the repository is successfully created, you will be taken to its details page or back to the list of repositories.
+*   **Identify your repository path:** The path to your Docker repository is crucial for pushing and pulling images. It follows this structure:
+
+    `[REGION]-docker.pkg.dev/[YOUR_PROJECT_ID]/[YOUR_REPOSITORY_NAME]`
+
+*   **Example:** If you chose:
+    *   Region: `us-central1`
+    *   Your Project ID is: `my-gcp-project-123`
+    *   Your Repository Name is: `gpt-researcher-repo`
+
+    Then your repository path would be:
+
+    `us-central1-docker.pkg.dev/my-gcp-project-123/gpt-researcher-repo`
+
+*   **Important:** Carefully note this full repository path. You will need it in subsequent steps, such as when tagging your Docker image before pushing it to Artifact Registry.
+
+You have now successfully created a Docker repository in Artifact Registry. You can proceed to build your Docker image and push it to this repository.

--- a/CLOUD_BUILD_INSTRUCTIONS.md
+++ b/CLOUD_BUILD_INSTRUCTIONS.md
@@ -1,0 +1,75 @@
+# Building and Pushing Docker Image using Google Cloud Build
+
+This guide provides the `gcloud` commands to configure Docker, build your Docker image using Google Cloud Build, and push it to your Artifact Registry repository.
+
+**Prerequisites:**
+
+*   You have a Google Cloud Project set up with billing enabled.
+*   You have enabled the Cloud Build API and Artifact Registry API.
+*   You have created an Artifact Registry Docker repository.
+*   You have `gcloud` CLI installed and authenticated.
+*   You have a `Dockerfile` in the root directory of your project.
+
+**Run these commands from the root directory of your project.**
+
+## 1. Configure Docker Credential Helper
+
+This command configures Docker to use `gcloud` as a credential helper. This allows Docker to authenticate with Artifact Registry using your Google Cloud credentials, so you don't have to manage Docker credentials manually.
+
+```bash
+gcloud auth configure-docker [REGION]-docker.pkg.dev
+```
+
+*   **Replace `[REGION]`** with the region of your Artifact Registry repository (e.g., `us-central1`, `europe-west1`).
+
+    *Example:*
+    ```bash
+    gcloud auth configure-docker us-central1-docker.pkg.dev
+    ```
+
+After running this command, Docker will be able to push and pull images from your Artifact Registry repository in the specified region.
+
+## 2. Build and Push the Image with Cloud Build
+
+This command uses Google Cloud Build to build your Docker image and then pushes it to your Artifact Registry repository. Cloud Build looks for a `Dockerfile` in your current directory (the build context).
+
+```bash
+gcloud builds submit --tag [REGION]-docker.pkg.dev/[PROJECT_ID]/[REPOSITORY_NAME]/[IMAGE_NAME]:[TAG] .
+```
+
+**Explanation of Placeholders:**
+
+*   `[REGION]`: The Google Cloud region where your Artifact Registry repository is located.
+    *   *Example:* `us-central1`
+*   `[PROJECT_ID]`: Your unique Google Cloud Project ID. You can find this in the Google Cloud Console.
+    *   *Example:* `my-gcp-project-123`
+*   `[REPOSITORY_NAME]`: The name you gave to your Artifact Registry repository.
+    *   *Example:* `gpt-researcher-repo`
+*   `[IMAGE_NAME]`: A name for your Docker image.
+    *   *Example:* `gpt-researcher-mcp` or `my-app`
+*   `[TAG]`: A tag for your image version. Common tags include `latest`, `v1.0`, or a specific commit SHA.
+    *   *Example:* `latest`, `v1.0.1`
+*   `.` (at the end): This dot signifies that the build context (the source code and `Dockerfile` for building the image) is the current directory. Ensure you run this command from the root of your project where the `Dockerfile` is located.
+
+**Complete Example:**
+
+If your details are:
+*   Region: `us-central1`
+*   Project ID: `my-gcp-project-123`
+*   Repository Name: `gpt-researcher-repo`
+*   Image Name: `gpt-researcher-mcp`
+*   Tag: `latest`
+
+The command would be:
+
+```bash
+gcloud builds submit --tag us-central1-docker.pkg.dev/my-gcp-project-123/gpt-researcher-repo/gpt-researcher-mcp:latest .
+```
+
+After running this command, Cloud Build will:
+1.  Upload your project files (the build context) to a Cloud Storage bucket.
+2.  Execute the Docker build using the `Dockerfile` found in the build context.
+3.  Tag the built image with the full path you specified.
+4.  Push the tagged image to your Artifact Registry repository.
+
+You can monitor the build progress in the Google Cloud Console under "Cloud Build". Once completed, your image will be available in Artifact Registry.

--- a/CLOUD_RUN_DEPLOYMENT.md
+++ b/CLOUD_RUN_DEPLOYMENT.md
@@ -1,0 +1,115 @@
+# Deploying Your Docker Image to Cloud Run
+
+This guide provides the `gcloud` command to deploy your Docker image from Artifact Registry to a new Cloud Run service.
+
+**Prerequisites:**
+
+*   You have successfully pushed your Docker image to Artifact Registry.
+*   You have the full URI of your Docker image (e.g., `[REGION]-docker.pkg.dev/[PROJECT_ID]/[REPOSITORY_NAME]/[IMAGE_NAME]:[TAG]`).
+*   You have `gcloud` CLI installed and authenticated with permissions to deploy Cloud Run services and access Artifact Registry.
+*   Your Google Cloud project has the Cloud Run API enabled.
+
+## Deploy to Cloud Run Command
+
+Execute the following command in your terminal, replacing the placeholders with your specific values.
+
+```bash
+gcloud run deploy [SERVICE_NAME] \
+    --image [IMAGE_URI] \
+    --platform managed \
+    --region [REGION] \
+    --port 8000 \
+    --set-env-vars "OPENAI_API_KEY=[YOUR_OPENAI_API_KEY],MCP_TRANSPORT=sse,TAVILY_API_KEY=[YOUR_TAVILY_API_KEY]" \
+    --allow-unauthenticated \
+    --min-instances 0 \
+    --max-instances 2 \
+    --cpu 1 \
+    --memory 512Mi \
+    --concurrency 80
+```
+
+**Explanation of Placeholders and Parameters:**
+
+*   `[SERVICE_NAME]`:
+    *   Choose a name for your new Cloud Run service. This will be part of the service's URL.
+    *   *Example:* `gpt-researcher-service`, `my-web-app`
+
+*   `[IMAGE_URI]`:
+    *   This is the full path to your Docker image in Artifact Registry. You should have noted this from the Cloud Build step.
+    *   *Format:* `[REGION]-docker.pkg.dev/[PROJECT_ID]/[REPOSITORY_NAME]/[IMAGE_NAME]:[TAG]`
+    *   *Example:* `us-central1-docker.pkg.dev/my-gcp-project-123/gpt-researcher-repo/gpt-researcher-mcp:latest`
+
+*   `--platform managed`:
+    *   Specifies that you are deploying to the fully managed Cloud Run environment, where Google handles the underlying infrastructure.
+
+*   `[REGION]`:
+    *   The Google Cloud region where you want to deploy your service.
+    *   *Recommendation:* Use the same region as your Artifact Registry repository to potentially reduce latency and costs.
+    *   *Example:* `us-central1`, `europe-west1`
+
+*   `--port 8000`:
+    *   The port number that your container application listens on for incoming requests. This should match the port exposed in your `Dockerfile` (e.g., `EXPOSE 8000`).
+    *   Our `gpt-researcher-mcp` server is configured to listen on port 8000 when in SSE mode.
+
+*   `--set-env-vars "OPENAI_API_KEY=[YOUR_OPENAI_API_KEY],MCP_TRANSPORT=sse,TAVILY_API_KEY=[YOUR_TAVILY_API_KEY]"`:
+    *   Sets environment variables for your Cloud Run service. Variables are comma-separated.
+    *   `OPENAI_API_KEY=[YOUR_OPENAI_API_KEY]`:
+        *   **CRITICAL:** Replace `[YOUR_OPENAI_API_KEY]` with your actual OpenAI API key. The application will not work without it.
+    *   `TAVILY_API_KEY=[YOUR_TAVILY_API_KEY]`:
+        *   **CRITICAL:** Replace `[YOUR_TAVILY_API_KEY]` with your actual Tavily API key if you are using Tavily for search. The application may not work as expected or at all for research tasks without it.
+    *   `MCP_TRANSPORT=sse`:
+        *   This explicitly sets the transport mode to Server-Sent Events (SSE), which is necessary for the Cloud Run deployment as STDIO is not suitable. While the `Dockerfile` also sets this, including it here ensures the correct mode.
+
+*   `--allow-unauthenticated`:
+    *   This flag makes your Cloud Run service publicly accessible over the internet. Anyone with the service URL can access it.
+    *   **Security Note:** If your service should be private and only accessible by other Google Cloud services or authenticated users, use `--no-allow-unauthenticated`. You would then need to configure IAM permissions or other authentication methods to access the service.
+
+*   `--min-instances 0`:
+    *   Allows Cloud Run to scale your service down to zero instances when there are no incoming requests. This is cost-effective for services with intermittent traffic. The service will quickly scale up when a new request arrives (cold start).
+
+*   `--max-instances 2`:
+    *   Sets the maximum number of container instances that Cloud Run can scale up to. Adjust this value based on your expected peak load and budget.
+    *   *Example:* `5`, `10`
+
+*   `--cpu 1`:
+    *   Allocates 1 virtual CPU to each container instance. You can specify fractional CPUs or more CPUs.
+    *   *Example:* `0.5`, `2`
+
+*   `--memory 512Mi`:
+    *   Allocates 512 MiB of memory to each container instance.
+    *   *Example:* `256Mi`, `1Gi`
+
+*   `--concurrency 80`:
+    *   The maximum number of concurrent requests that a single container instance can handle before Cloud Run attempts to scale up (if not at max-instances). The default is 80. Adjust based on your application's performance characteristics.
+
+**Example Command:**
+
+If your details are:
+*   Service Name: `gpt-researcher-service`
+*   Image URI: `us-central1-docker.pkg.dev/my-gcp-project-123/gpt-researcher-repo/gpt-researcher-mcp:latest`
+*   Region: `us-central1`
+*   OpenAI API Key: `sk-xxxxxxxxxxxxxxxxxxxxxx`
+*   Tavily API Key: `tvly-yyyyyyyyyyyyyyyyyyyyyy`
+
+The command would be:
+
+```bash
+gcloud run deploy gpt-researcher-service \
+    --image us-central1-docker.pkg.dev/my-gcp-project-123/gpt-researcher-repo/gpt-researcher-mcp:latest \
+    --platform managed \
+    --region us-central1 \
+    --port 8000 \
+    --set-env-vars "OPENAI_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxxx,MCP_TRANSPORT=sse,TAVILY_API_KEY=tvly-yyyyyyyyyyyyyyyyyyyyyy" \
+    --allow-unauthenticated \
+    --min-instances 0 \
+    --max-instances 2 \
+    --cpu 1 \
+    --memory 512Mi \
+    --concurrency 80
+```
+
+**Adjusting Performance Settings:**
+
+You can adjust `--cpu`, `--memory`, `--min-instances`, `--max-instances`, and `--concurrency` based on your application's needs and performance testing. Start with reasonable values and monitor your service's performance and cost in the Google Cloud Console.
+
+After running the command, `gcloud` will deploy your service. Once completed, it will output the URL of your deployed Cloud Run service. You can then access your application at this URL. You can also view and manage your service in the Google Cloud Console under "Cloud Run".

--- a/GOOGLE_CLOUD_SETUP.md
+++ b/GOOGLE_CLOUD_SETUP.md
@@ -1,0 +1,52 @@
+# Google Cloud Project Setup for Cloud Run
+
+This guide will walk you through setting up your Google Cloud project to deploy applications using Cloud Run.
+
+## 1. Create or Select a Google Cloud Project
+
+*   **Go to the Google Cloud Console:** Open your web browser and navigate to [https://console.cloud.google.com/](https://console.cloud.google.com/).
+*   **Select an Existing Project:**
+    *   If you have an existing Google Cloud Project you want to use, locate the project selector at the top of the page (it might display the name of your currently selected project).
+    *   Click on the project selector and choose your desired project from the list.
+*   **Create a New Project (if needed):**
+    *   If you don't have a project or want to create a new one, click on the project selector at the top of the page.
+    *   In the "Select a project" dialog, click on "**NEW PROJECT**".
+    *   Enter a descriptive **Project name**.
+    *   Select a **Billing account** if prompted (you can also link this later, but it's required to use services).
+    *   Choose an **Organization** and **Location** if applicable.
+    *   Click "**CREATE**".
+
+## 2. Enable Billing
+
+*   **Important:** A billing account must be linked to your project to use Google Cloud services, including Cloud Run.
+*   **Navigate to Billing:**
+    *   In the Google Cloud Console, click the **Navigation Menu** (the three horizontal lines in the top-left corner).
+    *   Select "**Billing**".
+*   **Link a Billing Account:**
+    *   If your project doesn't have a billing account linked, you'll see a prompt to "**Link a billing account**" or "**Manage billing accounts**".
+    *   Follow the on-screen instructions to either select an existing billing account or create a new one. You'll need to provide payment information if setting up a new billing account.
+
+## 3. Enable Necessary APIs
+
+To use Cloud Run and related services, you need to enable specific APIs for your project.
+
+*   **Go to the API Library:**
+    *   In the Google Cloud Console, click the **Navigation Menu**.
+    *   Go to "**APIs & Services**".
+    *   Select "**Library**".
+*   **Enable the Cloud Run API:**
+    *   In the API Library search bar, type "**Cloud Run API**" and press Enter.
+    *   Click on "**Cloud Run API**" in the search results.
+    *   If the API is not already enabled, click the "**ENABLE**" button. Wait for the process to complete.
+*   **Enable the Cloud Build API:**
+    *   Go back to the API Library (Navigation Menu > APIs & Services > Library).
+    *   In the search bar, type "**Cloud Build API**" and press Enter.
+    *   Click on "**Cloud Build API**" in the search results.
+    *   If the API is not already enabled, click the "**ENABLE**" button. Wait for the process to complete.
+*   **Enable the Artifact Registry API:**
+    *   Go back to the API Library.
+    *   In the search bar, type "**Artifact Registry API**" and press Enter.
+    *   Click on "**Artifact Registry API**" in the search results.
+    *   If the API is not already enabled, click the "**ENABLE**" button. Wait for the process to complete.
+
+Once these steps are completed, your Google Cloud project will be configured with the basic requirements for deploying applications with Cloud Run.

--- a/server.py
+++ b/server.py
@@ -11,6 +11,7 @@ import uuid
 import logging
 from typing import Dict, Any, Optional, List
 from dotenv import load_dotenv
+from fastapi.responses import JSONResponse
 from fastmcp import FastMCP
 from gpt_researcher import GPTResearcher
 
@@ -268,6 +269,12 @@ def research_query(topic: str, goal: str, report_format: str = "research_report"
         A formatted prompt for research
     """
     return create_research_prompt(topic, goal, report_format)
+
+
+@mcp.app.get("/health")
+async def health_check():
+    """Basic health check endpoint."""
+    return JSONResponse({"status": "healthy"})
 
 
 def run_server():


### PR DESCRIPTION
Adds a /health endpoint to server.py for reliable health checks in containerized environments like Cloud Run.

Includes comprehensive markdown documentation for setting up Google Cloud Project, Artifact Registry, Cloud Build, and deploying the application to Cloud Run.