### PR TITLE
fix: Correct health check route registration in server.py

### DIFF
--- a/server.py
+++ b/server.py
@@ -271,7 +271,7 @@ def research_query(topic: str, goal: str, report_format: str = "research_report"
     return create_research_prompt(topic, goal, report_format)
 
 
-@mcp.app.get("/health")
+@mcp.get("/health")
 async def health_check():
     """Basic health check endpoint."""
     return JSONResponse({"status": "healthy"})


### PR DESCRIPTION
Changes the health check route decorator from "@mcp.app.get("/health")" to "@mcp.get("/health")" to correctly register the endpoint with the FastMCP application instance. This resolves an AttributeError that prevented the server from starting.

(This commit may also include prior documentation and README changes due to development environment behavior.)